### PR TITLE
feat: create deliverers feature with bdd, docs and frontend list

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,16 @@ O objetivo desta base é permitir que o time comece a desenvolver rapidamente co
 
 ## Estrutura do projeto
 - `service/backend/`: código do backend Django
-- `app/frontend/`: esqueleto inicial do frontend Vite + React
+- `app/frontend/`: frontend Vite + React (lista funcional de entregadores)
 - `docker-compose.yml`: orquestra o backend Django e PostgreSQL
 - `.env.example`: variáveis de ambiente para desenvolvimento
+- `docs/`: source of truth de arquitetura, design system e BDD
+
+## Documentação oficial
+- `docs/architecture.md`
+- `docs/design-system.md`
+- `docs/bdd-guidelines.md`
+- `docs/deliverers.md`
 
 ## Como rodar localmente
 1. Copie as variáveis de ambiente:
@@ -23,10 +30,11 @@ O objetivo desta base é permitir que o time comece a desenvolver rapidamente co
 3. A API estará disponível em `http://localhost:8000`
 
 ### Endpoints de exemplo
+- `GET /api/deliverers/?status=AVAILABLE&region=Zona Sul`
 - `POST /api/deliverers/`
 - `PATCH /api/deliverers/{deliverer_id}/status/`
-- `POST /api/orders/assign/`
-- `POST /api/orders/{order_id}/reassign/`
+- `POST /api/orders/assign/` (automática ou manual com `deliverer_id`)
+- `POST /api/orders/{order_id}/reassign/` (com `reason`: `timeout` ou `refused`)
 
 ### Frontend local
 O frontend inicial está em `app/frontend`.
@@ -47,7 +55,7 @@ pytest
 1. Crie um novo domínio dentro de `service/backend/delivery/domain/` ou extraia um app para `service/backend/<feature>`.
 2. Adicione portos (`ports.py`) e implementação de repositórios em `infrastructure/repositories.py`.
 3. Crie regras de aplicação em `application/services.py`.
-4. Exponha a API em `http/controllers.py` e registre as rotas em `http/urls.py`.
+4. Exponha a API em `http/views.py` e registre as rotas em `http/urls.py`.
 5. Adicione cenários BDD em `service/backend/tests/features/` e passos em `service/backend/tests/steps/`.
 
 ## Boas práticas de colaboração

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1,12 +1,143 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Badge from './components/Badge'
+import Button from './components/Button'
+import Card from './components/Card'
+
+type DelivererStatus = 'AVAILABLE' | 'OCCUPIED' | 'OFFLINE'
+
+type Deliverer = {
+  id: string
+  name: string
+  phone: string
+  region: string
+  status: DelivererStatus
+}
+
+type DeliverersResponse = {
+  items: Deliverer[]
+}
 
 function App() {
-  const [message] = useState('Delivery App frontend loaded')
+  const [items, setItems] = useState<Deliverer[]>([])
+  const [filter, setFilter] = useState<'ALL' | DelivererStatus>('ALL')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const fetchDeliverers = useCallback(async () => {
+    setLoading(true)
+    setError('')
+
+    try {
+      const query = filter === 'ALL' ? '' : `?status=${filter}`
+      const response = await fetch(`/api/deliverers/${query}`)
+      if (!response.ok) {
+        throw new Error('Falha ao carregar entregadores')
+      }
+      const data: DeliverersResponse = await response.json()
+      setItems(data.items)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Erro inesperado'
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }, [filter])
+
+  useEffect(() => {
+    void fetchDeliverers()
+  }, [fetchDeliverers])
+
+  const title = useMemo(() => {
+    if (filter === 'ALL') {
+      return 'Todos os entregadores'
+    }
+    return `Entregadores ${filter}`
+  }, [filter])
+
+  const markAsOccupied = useCallback(async (delivererId: string) => {
+    setError('')
+    try {
+      const response = await fetch(`/api/deliverers/${delivererId}/status/`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ status: 'OCCUPIED' }),
+      })
+      if (!response.ok) {
+        throw new Error('Nao foi possivel atualizar o status')
+      }
+      await fetchDeliverers()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Erro inesperado'
+      setError(message)
+    }
+  }, [fetchDeliverers])
 
   return (
-    <main className="app-shell">
-      <h1>Delivery App</h1>
-      <p>{message}</p>
+    <main className="page">
+      <section className="header">
+        <h1 className="title">Gestao de Entregadores</h1>
+        <p className="subtitle">Acompanhe disponibilidade e acione entregadores rapidamente.</p>
+      </section>
+
+      <section className="toolbar">
+        <Button variant={filter === 'ALL' ? 'primary' : 'secondary'} onClick={() => setFilter('ALL')}>
+          Todos
+        </Button>
+        <Button variant={filter === 'AVAILABLE' ? 'primary' : 'secondary'} onClick={() => setFilter('AVAILABLE')}>
+          Disponiveis
+        </Button>
+        <Button variant={filter === 'OCCUPIED' ? 'primary' : 'secondary'} onClick={() => setFilter('OCCUPIED')}>
+          Ocupados
+        </Button>
+        <Button variant={filter === 'OFFLINE' ? 'primary' : 'secondary'} onClick={() => setFilter('OFFLINE')}>
+          Offline
+        </Button>
+      </section>
+
+      <section className="content">
+        <div className="content-header">
+          <h2>{title}</h2>
+          <Button variant="ghost" onClick={() => void fetchDeliverers()}>
+            Atualizar
+          </Button>
+        </div>
+
+        {loading && <p className="status-message">Carregando entregadores...</p>}
+
+        {error && <p className="status-message status-message--error">{error}</p>}
+
+        {!loading && !error && items.length === 0 && (
+          <Card>
+            <p className="empty">Nenhum entregador encontrado para este filtro.</p>
+          </Card>
+        )}
+
+        <div className="cards">
+          {items.map((deliverer) => (
+            <Card key={deliverer.id}>
+              <div className="card-header">
+                <div>
+                  <h3>{deliverer.name}</h3>
+                  <p>{deliverer.phone}</p>
+                </div>
+                <Badge status={deliverer.status} />
+              </div>
+
+              <p className="region">Regiao: {deliverer.region}</p>
+
+              <Button
+                fullWidth
+                disabled={deliverer.status !== 'AVAILABLE'}
+                onClick={() => void markAsOccupied(deliverer.id)}
+              >
+                {deliverer.status === 'AVAILABLE' ? 'Marcar como ocupado' : 'Sem acao disponivel'}
+              </Button>
+            </Card>
+          ))}
+        </div>
+      </section>
     </main>
   )
 }

--- a/app/frontend/src/components/Badge.tsx
+++ b/app/frontend/src/components/Badge.tsx
@@ -1,0 +1,12 @@
+type BadgeStatus = 'AVAILABLE' | 'OCCUPIED' | 'OFFLINE'
+
+type BadgeProps = {
+  status: BadgeStatus
+}
+
+function Badge({ status }: BadgeProps) {
+  const className = `badge badge--${status.toLowerCase()}`
+  return <span className={className}>{status}</span>
+}
+
+export default Badge

--- a/app/frontend/src/components/Button.tsx
+++ b/app/frontend/src/components/Button.tsx
@@ -1,0 +1,23 @@
+import type { ButtonHTMLAttributes, PropsWithChildren } from 'react'
+
+type Variant = 'primary' | 'secondary' | 'ghost'
+
+type ButtonProps = PropsWithChildren<
+  ButtonHTMLAttributes<HTMLButtonElement> & {
+    variant?: Variant
+    fullWidth?: boolean
+  }
+>
+
+function Button({ variant = 'primary', fullWidth = false, className = '', children, ...props }: ButtonProps) {
+  return (
+    <button
+      className={`btn btn--${variant} ${fullWidth ? 'btn--full' : ''} ${className}`.trim()}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+}
+
+export default Button

--- a/app/frontend/src/components/Card.tsx
+++ b/app/frontend/src/components/Card.tsx
@@ -1,0 +1,11 @@
+import type { PropsWithChildren } from 'react'
+
+type CardProps = PropsWithChildren<{
+  className?: string
+}>
+
+function Card({ className = '', children }: CardProps) {
+  return <article className={`card ${className}`.trim()}>{children}</article>
+}
+
+export default Card

--- a/app/frontend/src/styles.css
+++ b/app/frontend/src/styles.css
@@ -1,18 +1,191 @@
 :root {
-  font-family: system-ui, sans-serif;
-  color: #1f2937;
-  background: #f8fafc;
+  font-family: Inter, system-ui, sans-serif;
+  color: #111827;
+  background: #ffffff;
+  --primary: #22c55e;
+  --secondary: #3b82f6;
+  --surface: #f9fafb;
+  --border: #e5e7eb;
+  --text-secondary: #6b7280;
+  --error: #dc2626;
+  --status-available-bg: #dcfce7;
+  --status-available-text: #166534;
+  --status-occupied-bg: #fef9c3;
+  --status-occupied-text: #854d0e;
+  --status-offline-bg: #e5e7eb;
+  --status-offline-text: #374151;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
+  background: linear-gradient(180deg, #ffffff 0%, #f9fafb 100%);
 }
 
-.app-shell {
-  max-width: 680px;
-  margin: 4rem auto;
-  padding: 2rem;
-  border-radius: 16px;
-  background: white;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+.page {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 20px 16px 32px;
+}
+
+.header {
+  margin-bottom: 16px;
+}
+
+.title {
+  margin: 0;
+  font-size: 24px;
+}
+
+.subtitle {
+  margin: 8px 0 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.toolbar {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.content-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.content-header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.cards {
+  display: grid;
+  gap: 12px;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px;
+}
+
+.card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.card-header h3 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.card-header p {
+  margin: 4px 0 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.region {
+  margin: 10px 0 12px;
+  font-size: 13px;
+}
+
+.badge {
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.badge--available {
+  background: var(--status-available-bg);
+  color: var(--status-available-text);
+}
+
+.badge--occupied {
+  background: var(--status-occupied-bg);
+  color: var(--status-occupied-text);
+}
+
+.badge--offline {
+  background: var(--status-offline-bg);
+  color: var(--status-offline-text);
+}
+
+.btn {
+  border: 0;
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn--full {
+  width: 100%;
+}
+
+.btn--primary {
+  background: var(--primary);
+  color: #ffffff;
+}
+
+.btn--secondary {
+  background: var(--secondary);
+  color: #ffffff;
+}
+
+.btn--ghost {
+  background: #eef2ff;
+  color: #1f2937;
+}
+
+.status-message {
+  margin: 0;
+  font-size: 14px;
+}
+
+.status-message--error {
+  color: var(--error);
+}
+
+.empty {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+@media (min-width: 768px) {
+  .page {
+    padding: 28px 20px 40px;
+  }
+
+  .toolbar {
+    grid-template-columns: repeat(4, auto);
+    justify-content: start;
+  }
+
+  .cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -5,5 +5,11 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 4173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
   },
 })

--- a/docs/deliverers.md
+++ b/docs/deliverers.md
@@ -1,0 +1,62 @@
+# Deliverers Feature Guide
+
+## Escopo
+Feature inicial para gerir entregadores e atribuicao de pedidos.
+
+## Entidades
+- Deliverer
+  - `id`, `name`, `phone`, `region`, `status`
+- Order
+  - `id`, `region`, `status`, `assigned_deliverer_id`
+
+## Status
+- Deliverer: `AVAILABLE`, `OCCUPIED`, `OFFLINE`
+- Order: `PENDING`, `IN_DELIVERY`, `WAITING`
+
+## Regras de negocio
+1. Cadastro cria entregador com status `AVAILABLE`.
+2. Atualizacao de status altera apenas o entregador alvo.
+3. Atribuicao automatica seleciona primeiro `AVAILABLE` da mesma regiao.
+4. Atribuicao manual exige entregador `AVAILABLE` e da mesma regiao.
+5. Nao atribuir quando entregador estiver `OCCUPIED` ou `OFFLINE`.
+6. Reatribuicao por `refused` ou `timeout` libera entregador atual e tenta novo.
+7. Sem entregador disponivel na reatribuicao, pedido vai para `WAITING`.
+
+## Endpoints
+- `GET /api/deliverers/?status=AVAILABLE&region=Zona Sul`
+- `POST /api/deliverers/`
+- `PATCH /api/deliverers/{deliverer_id}/status/`
+- `POST /api/orders/assign/` (automatico ou manual com `deliverer_id`)
+- `POST /api/orders/{order_id}/reassign/` (body com `reason`)
+
+## Payloads
+### Criar entregador
+```json
+{
+  "name": "Ana",
+  "phone": "11999999999",
+  "region": "Zona Sul"
+}
+```
+
+### Atribuicao manual
+```json
+{
+  "order_id": "uuid",
+  "region": "Zona Sul",
+  "deliverer_id": "uuid"
+}
+```
+
+### Reatribuicao
+```json
+{
+  "reason": "refused"
+}
+```
+
+## Como evoluir sem quebrar
+- Adicionar nova regra primeiro em BDD
+- Implementar no service
+- Ajustar controller apenas para receber/retornar payload
+- Manter repositorio sem regra de negocio

--- a/service/backend/delivery/application/services.py
+++ b/service/backend/delivery/application/services.py
@@ -34,7 +34,17 @@ class DelivererService:
         )
         return self.deliverer_repo.save(updated)
 
-    def assign_order(self, order_id: UUID, region: str) -> Order:
+    def list_deliverers(
+        self,
+        status: Optional[DelivererStatus] = None,
+        region: Optional[str] = None,
+    ) -> list[Deliverer]:
+        return self.deliverer_repo.list_deliverers(
+            status=status.value if status else None,
+            region=region,
+        )
+
+    def assign_deliverer(self, order_id: UUID, region: str, deliverer_id: Optional[UUID] = None) -> Order:
         order = self.order_repo.get_by_id(order_id)
         if order is None:
             order = Order(id=order_id, region=region,
@@ -43,7 +53,18 @@ class DelivererService:
         if order.assigned_deliverer_id is not None:
             return order
 
-        deliverer = self.deliverer_repo.find_available_by_region(region)
+        if deliverer_id is not None:
+            deliverer = self.deliverer_repo.get_by_id(deliverer_id)
+            if deliverer is None:
+                raise ValueError('Deliverer not found')
+            if deliverer.region != region:
+                raise ValueError(
+                    'Deliverer region does not match order region')
+            if deliverer.status != DelivererStatus.AVAILABLE:
+                raise ValueError('Deliverer is not available')
+        else:
+            deliverer = self.deliverer_repo.find_available_by_region(region)
+
         if deliverer is None:
             raise ValueError('No available deliverer in region')
 
@@ -64,7 +85,10 @@ class DelivererService:
         )
         return self.order_repo.save(assigned)
 
-    def reassign_order(self, order_id: UUID) -> Order:
+    def reassign_deliverer(self, order_id: UUID, reason: str = 'timeout') -> Order:
+        if reason not in ('timeout', 'refused'):
+            raise ValueError('Invalid reassign reason')
+
         order = self.order_repo.get_by_id(order_id)
         if order is None:
             raise ValueError('Order not found')

--- a/service/backend/delivery/domain/ports.py
+++ b/service/backend/delivery/domain/ports.py
@@ -15,6 +15,10 @@ class DelivererRepository(ABC):
         pass
 
     @abstractmethod
+    def list_deliverers(self, status: Optional[str] = None, region: Optional[str] = None) -> list[Deliverer]:
+        pass
+
+    @abstractmethod
     def find_available_by_region(self, region: str, exclude_id: Optional[UUID] = None) -> Optional[Deliverer]:
         pass
 

--- a/service/backend/delivery/http/urls.py
+++ b/service/backend/delivery/http/urls.py
@@ -1,8 +1,8 @@
 from django.urls import path
-from delivery.http.views import create_deliverer, update_deliverer_status, assign_order, reassign_order
+from delivery.http.views import deliverers_collection, update_deliverer_status, assign_order, reassign_order
 
 urlpatterns = [
-    path('deliverers/', create_deliverer, name='create-deliverer'),
+    path('deliverers/', deliverers_collection, name='deliverers-collection'),
     path('deliverers/<uuid:deliverer_id>/status/',
          update_deliverer_status, name='update-deliverer-status'),
     path('orders/assign/', assign_order, name='assign-order'),

--- a/service/backend/delivery/http/views.py
+++ b/service/backend/delivery/http/views.py
@@ -14,8 +14,34 @@ def parse_body(request: HttpRequest) -> dict:
         return {}
 
 
-@require_http_methods(['POST'])
-def create_deliverer(request: HttpRequest) -> JsonResponse:
+@require_http_methods(['GET', 'POST'])
+def deliverers_collection(request: HttpRequest) -> JsonResponse:
+    if request.method == 'GET':
+        status_value = request.GET.get('status')
+        region = request.GET.get('region')
+
+        status = None
+        if status_value:
+            try:
+                status = DelivererStatus(status_value)
+            except ValueError:
+                return JsonResponse({'error': 'invalid status filter'}, status=400)
+
+        deliverers = deliverer_service.list_deliverers(
+            status=status, region=region)
+        return JsonResponse({
+            'items': [
+                {
+                    'id': str(deliverer.id),
+                    'name': deliverer.name,
+                    'phone': deliverer.phone,
+                    'region': deliverer.region,
+                    'status': deliverer.status.value,
+                }
+                for deliverer in deliverers
+            ]
+        })
+
     data = parse_body(request)
     name = data.get('name')
     phone = data.get('phone')
@@ -60,8 +86,14 @@ def assign_order(request: HttpRequest) -> JsonResponse:
     if not order_id or not region:
         return JsonResponse({'error': 'order_id and region are required'}, status=400)
 
+    deliverer_id = data.get('deliverer_id')
+
     try:
-        order = deliverer_service.assign_order(UUID(order_id), region)
+        order = deliverer_service.assign_deliverer(
+            UUID(order_id),
+            region,
+            UUID(deliverer_id) if deliverer_id else None,
+        )
         return JsonResponse({
             'order_id': str(order.id),
             'status': order.status.value,
@@ -73,8 +105,11 @@ def assign_order(request: HttpRequest) -> JsonResponse:
 
 @require_http_methods(['POST'])
 def reassign_order(request: HttpRequest, order_id: UUID) -> JsonResponse:
+    data = parse_body(request)
+    reason = data.get('reason', 'timeout')
+
     try:
-        order = deliverer_service.reassign_order(order_id)
+        order = deliverer_service.reassign_deliverer(order_id, reason=reason)
         return JsonResponse({
             'order_id': str(order.id),
             'status': order.status.value,

--- a/service/backend/delivery/infrastructure/repositories.py
+++ b/service/backend/delivery/infrastructure/repositories.py
@@ -39,6 +39,24 @@ class DelivererRepositoryImpl(DelivererRepository):
             status=DelivererStatus(model.status),
         )
 
+    def list_deliverers(self, status: Optional[str] = None, region: Optional[str] = None) -> list[Deliverer]:
+        query = DelivererModel.objects.all()
+        if status:
+            query = query.filter(status=status)
+        if region:
+            query = query.filter(region=region)
+
+        return [
+            Deliverer(
+                id=model.id,
+                name=model.name,
+                phone=model.phone,
+                region=model.region,
+                status=DelivererStatus(model.status),
+            )
+            for model in query.order_by('name')
+        ]
+
     def find_available_by_region(self, region: str, exclude_id: Optional[UUID] = None) -> Optional[Deliverer]:
         query = DelivererModel.objects.filter(
             region=region, status=DelivererStatus.AVAILABLE.value)

--- a/service/backend/tests/features/deliverers.feature
+++ b/service/backend/tests/features/deliverers.feature
@@ -2,24 +2,47 @@ Feature: Gestão de entregadores
 
     Scenario: cadastrar entregador com sucesso
         Given nenhum entregador existe
-        When o cliente registra um entregador com nome "Ana" telefone "11999999999" região "Zona Sul"
-        Then o entregador "Ana" deve ser criado com status "AVAILABLE" na região "Zona Sul"
+        When o cliente registra um entregador com nome "Ana" telefone "11999999999" regiao "Zona Sul"
+        Then o entregador "Ana" deve ser criado com status "AVAILABLE" na regiao "Zona Sul"
 
     Scenario: atualizar status do entregador
-        Given um entregador existente com nome "Ana" e região "Zona Sul"
+        Given um entregador existente com nome "Ana" e regiao "Zona Sul"
         When o entregador for atualizado para status "OCCUPIED"
         Then o entregador deve ter status "OCCUPIED"
 
+    Scenario: listar entregadores por status
+        Given entregadores com status diferentes cadastrados
+        When a listagem de entregadores for solicitada com filtro de status "AVAILABLE"
+        Then apenas entregadores com status "AVAILABLE" devem ser retornados
+
     Scenario: atribuir entregador automaticamente
-        Given uma ordem pendente na região "Zona Sul"
-        And um entregador disponível na região "Zona Sul"
-        When a atribuição automática for solicitada para a ordem
+        Given uma ordem pendente na regiao "Zona Sul"
+        And um entregador disponivel na regiao "Zona Sul"
+        When a atribuicao automatica for solicitada para a ordem
         Then a ordem deve ser marcada como "IN_DELIVERY"
         And o entregador deve ser marcado como "OCCUPIED"
 
-    Scenario: reatribuir pedido após recusa
-        Given uma ordem em entrega na região "Zona Sul" atribuída ao entregador "Ana"
-        And outro entregador disponível na região "Zona Sul"
-        When a reatribuição for solicitada para a ordem
-        Then a nova atribuição deve escolher outro entregador disponível
+    Scenario: atribuir entregador manualmente
+        Given uma ordem pendente na regiao "Zona Sul"
+        And um entregador com nome "Bruno" disponivel na regiao "Zona Sul"
+        When a atribuicao manual for solicitada para a ordem com o entregador "Bruno"
+        Then a ordem deve ser atribuida ao entregador "Bruno"
+
+    Scenario: nao atribuir quando nao ha entregador disponivel
+        Given uma ordem pendente na regiao "Centro"
+        And nao existe entregador disponivel na regiao "Centro"
+        When a atribuicao automatica for solicitada para a ordem
+        Then o sistema deve retornar erro "No available deliverer in region"
+
+    Scenario: impedir atribuicao para entregador ocupado
+        Given uma ordem pendente na regiao "Zona Norte"
+        And um entregador com nome "Leo" ocupado na regiao "Zona Norte"
+        When a atribuicao manual for solicitada para a ordem com o entregador "Leo"
+        Then o sistema deve retornar erro "Deliverer is not available"
+
+    Scenario: reatribuir pedido apos recusa
+        Given uma ordem em entrega na regiao "Zona Sul" atribuida ao entregador "Ana"
+        And outro entregador disponivel na regiao "Zona Sul"
+        When a reatribuicao for solicitada para a ordem por motivo "refused"
+        Then a nova atribuicao deve escolher outro entregador disponivel
         And a ordem deve continuar em "IN_DELIVERY"

--- a/service/backend/tests/steps/test_deliverers_steps.py
+++ b/service/backend/tests/steps/test_deliverers_steps.py
@@ -3,17 +3,20 @@ from uuid import uuid4
 
 import pytest
 from django.test import Client
-from pytest_bdd import scenarios, given, when, then, parsers
+from pytest_bdd import given, parsers, scenarios, then, when
 
 from delivery.domain.enums import DelivererStatus, OrderStatus
 from delivery.infrastructure.models import DelivererModel, OrderModel
 
 scenarios('../features/deliverers.feature')
+pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
 def context() -> dict:
-    return {}
+    return {
+        'deliverers_by_name': {},
+    }
 
 
 @given('nenhum entregador existe')
@@ -21,8 +24,8 @@ def no_deliverers():
     DelivererModel.objects.all().delete()
 
 
-@given(parsers.parse('um entregador existente com nome "{name}" e região "{region}"'))
-def existing_deliverer(client: Client, name: str, region: str, context: dict):
+@given(parsers.parse('um entregador existente com nome "{name}" e regiao "{region}"'))
+def existing_deliverer(client: Client, context: dict, name: str, region: str):
     response = client.post(
         '/api/deliverers/',
         data=json.dumps(
@@ -30,12 +33,44 @@ def existing_deliverer(client: Client, name: str, region: str, context: dict):
         content_type='application/json',
     )
     assert response.status_code == 201
-    context['deliverer'] = response.json()
-    return context
+    payload = response.json()
+    context['deliverer'] = payload
+    context['deliverers_by_name'][name] = payload
 
 
-@given(parsers.parse('um entregador disponível na região "{region}"'))
-def available_deliverer(client: Client, region: str, context: dict):
+@given('entregadores com status diferentes cadastrados')
+def deliverers_with_different_statuses(client: Client):
+    DelivererModel.objects.all().delete()
+
+    first = client.post(
+        '/api/deliverers/',
+        data=json.dumps(
+            {'name': 'Ana', 'phone': '11111111111', 'region': 'Zona Sul'}),
+        content_type='application/json',
+    )
+    second = client.post(
+        '/api/deliverers/',
+        data=json.dumps(
+            {'name': 'Bruno', 'phone': '22222222222', 'region': 'Zona Sul'}),
+        content_type='application/json',
+    )
+    assert first.status_code == 201
+    assert second.status_code == 201
+
+    bruno_id = second.json()['id']
+    DelivererModel.objects.filter(id=bruno_id).update(
+        status=DelivererStatus.OCCUPIED.value)
+
+
+@given(parsers.parse('uma ordem pendente na regiao "{region}"'))
+def pending_order(context: dict, region: str):
+    order = OrderModel.objects.create(
+        region=region, status=OrderStatus.PENDING.value)
+    context['order'] = {'id': str(order.id), 'region': order.region}
+
+
+@given(parsers.parse('um entregador disponivel na regiao "{region}"'))
+def available_deliverer(client: Client, context: dict, region: str):
     response = client.post(
         '/api/deliverers/',
         data=json.dumps(
@@ -43,20 +78,13 @@ def available_deliverer(client: Client, region: str, context: dict):
         content_type='application/json',
     )
     assert response.status_code == 201
-    context['deliverer'] = response.json()
-    return context
+    payload = response.json()
+    context['deliverer'] = payload
+    context['deliverers_by_name']['Carlos'] = payload
 
 
-@given(parsers.parse('uma ordem pendente na região "{region}"'))
-def pending_order(region: str, context: dict):
-    order = OrderModel.objects.create(
-        region=region, status=OrderStatus.PENDING.value)
-    context['order'] = {'id': str(order.id), 'region': order.region}
-    return context
-
-
-@given(parsers.parse('uma ordem em entrega na região "{region}" atribuída ao entregador "{name}"'))
-def in_delivery_order(client: Client, region: str, name: str, context: dict):
+@given(parsers.parse('um entregador com nome "{name}" disponivel na regiao "{region}"'))
+def available_named_deliverer(client: Client, context: dict, name: str, region: str):
     response = client.post(
         '/api/deliverers/',
         data=json.dumps(
@@ -64,23 +92,73 @@ def in_delivery_order(client: Client, region: str, name: str, context: dict):
         content_type='application/json',
     )
     assert response.status_code == 201
+    payload = response.json()
+    context['deliverers_by_name'][name] = payload
+
+
+@given(parsers.parse('nao existe entregador disponivel na regiao "{region}"'))
+def no_available_deliverer_in_region(region: str):
+    DelivererModel.objects.filter(
+        region=region, status=DelivererStatus.AVAILABLE.value).delete()
+
+
+@given(parsers.parse('um entregador com nome "{name}" ocupado na regiao "{region}"'))
+def occupied_named_deliverer(client: Client, context: dict, name: str, region: str):
+    response = client.post(
+        '/api/deliverers/',
+        data=json.dumps(
+            {'name': name, 'phone': '11966666666', 'region': region}),
+        content_type='application/json',
+    )
+    assert response.status_code == 201
+    payload = response.json()
+    DelivererModel.objects.filter(id=payload['id']).update(
+        status=DelivererStatus.OCCUPIED.value)
+    context['deliverers_by_name'][name] = payload
+
+
+@given(parsers.parse('uma ordem em entrega na regiao "{region}" atribuida ao entregador "{name}"'))
+def in_delivery_order(client: Client, context: dict, region: str, name: str):
+    response = client.post(
+        '/api/deliverers/',
+        data=json.dumps(
+            {'name': name, 'phone': '11955555555', 'region': region}),
+        content_type='application/json',
+    )
+    assert response.status_code == 201
     deliverer = response.json()
     DelivererModel.objects.filter(id=deliverer['id']).update(
         status=DelivererStatus.OCCUPIED.value)
+
     order = OrderModel.objects.create(
         id=uuid4(),
         region=region,
         status=OrderStatus.IN_DELIVERY.value,
         assigned_deliverer_id=deliverer['id'],
     )
-    context['order'] = {'id': str(
-        order.id), 'region': order.region, 'assigned_deliverer_id': deliverer['id']}
-    context['deliverer'] = deliverer
-    return context
+    context['order'] = {
+        'id': str(order.id),
+        'region': order.region,
+        'assigned_deliverer_id': deliverer['id'],
+    }
+    context['deliverers_by_name'][name] = deliverer
 
 
-@when(parsers.parse('o cliente registra um entregador com nome "{name}" telefone "{phone}" região "{region}"'))
-def register_deliverer(client: Client, name: str, phone: str, region: str, context: dict):
+@given(parsers.parse('outro entregador disponivel na regiao "{region}"'))
+def second_available_deliverer(client: Client, context: dict, region: str):
+    response = client.post(
+        '/api/deliverers/',
+        data=json.dumps(
+            {'name': 'Mario', 'phone': '11944444444', 'region': region}),
+        content_type='application/json',
+    )
+    assert response.status_code == 201
+    payload = response.json()
+    context['deliverers_by_name']['Mario'] = payload
+
+
+@when(parsers.parse('o cliente registra um entregador com nome "{name}" telefone "{phone}" regiao "{region}"'))
+def register_deliverer(client: Client, context: dict, name: str, phone: str, region: str):
     response = client.post(
         '/api/deliverers/',
         data=json.dumps({'name': name, 'phone': phone, 'region': region}),
@@ -88,11 +166,10 @@ def register_deliverer(client: Client, name: str, phone: str, region: str, conte
     )
     assert response.status_code == 201
     context['response'] = response.json()
-    return context
 
 
 @when(parsers.parse('o entregador for atualizado para status "{status}"'))
-def update_status(client: Client, context: dict, status: str):
+def update_deliverer_status(client: Client, context: dict, status: str):
     deliverer_id = context['deliverer']['id']
     response = client.patch(
         f'/api/deliverers/{deliverer_id}/status/',
@@ -101,32 +178,54 @@ def update_status(client: Client, context: dict, status: str):
     )
     assert response.status_code == 200
     context['response'] = response.json()
-    return context
 
 
-@when('a atribuição automática for solicitada para a ordem')
-def assign_order(client: Client, context: dict):
+@when(parsers.parse('a listagem de entregadores for solicitada com filtro de status "{status}"'))
+def list_deliverers_by_status(client: Client, context: dict, status: str):
+    response = client.get(f'/api/deliverers/?status={status}')
+    assert response.status_code == 200
+    context['response'] = response.json()
+
+
+@when('a atribuicao automatica for solicitada para a ordem')
+def assign_order_automatically(client: Client, context: dict):
     order = context['order']
     response = client.post(
         '/api/orders/assign/',
         data=json.dumps({'order_id': order['id'], 'region': order['region']}),
         content_type='application/json',
     )
-    assert response.status_code == 200
+    context['status_code'] = response.status_code
     context['response'] = response.json()
-    return context
 
 
-@when('a reatribuição for solicitada para a ordem')
-def reassign_order(client: Client, context: dict):
+@when(parsers.parse('a atribuicao manual for solicitada para a ordem com o entregador "{name}"'))
+def assign_order_manually(client: Client, context: dict, name: str):
+    order = context['order']
+    deliverer_id = context['deliverers_by_name'][name]['id']
+    response = client.post(
+        '/api/orders/assign/',
+        data=json.dumps(
+            {'order_id': order['id'], 'region': order['region'], 'deliverer_id': deliverer_id}),
+        content_type='application/json',
+    )
+    context['status_code'] = response.status_code
+    context['response'] = response.json()
+
+
+@when(parsers.parse('a reatribuicao for solicitada para a ordem por motivo "{reason}"'))
+def reassign_order(client: Client, context: dict, reason: str):
     order_id = context['order']['id']
-    response = client.post(f'/api/orders/{order_id}/reassign/')
+    response = client.post(
+        f'/api/orders/{order_id}/reassign/',
+        data=json.dumps({'reason': reason}),
+        content_type='application/json',
+    )
     assert response.status_code == 200
     context['response'] = response.json()
-    return context
 
 
-@then(parsers.parse('o entregador "{name}" deve ser criado com status "{status}" na região "{region}"'))
+@then(parsers.parse('o entregador "{name}" deve ser criado com status "{status}" na regiao "{region}"'))
 def assert_deliverer_created(context: dict, name: str, status: str, region: str):
     payload = context['response']
     assert payload['name'] == name
@@ -135,9 +234,16 @@ def assert_deliverer_created(context: dict, name: str, status: str, region: str)
 
 
 @then(parsers.parse('o entregador deve ter status "{status}"'))
-def assert_status_updated(context: dict, status: str):
+def assert_deliverer_status(context: dict, status: str):
     payload = context['response']
     assert payload['status'] == status
+
+
+@then(parsers.parse('apenas entregadores com status "{status}" devem ser retornados'))
+def assert_list_filtered_by_status(context: dict, status: str):
+    items = context['response']['items']
+    assert len(items) > 0
+    assert all(item['status'] == status for item in items)
 
 
 @then(parsers.parse('a ordem deve ser marcada como "{status}"'))
@@ -148,20 +254,31 @@ def assert_order_status(context: dict, status: str):
 
 @then('o entregador deve ser marcado como "OCCUPIED"')
 def assert_deliverer_occupied(context: dict):
-    order = context['response']
-    assert order['assigned_deliverer_id'] is not None
-    deliverer = DelivererModel.objects.get(id=order['assigned_deliverer_id'])
+    payload = context['response']
+    deliverer = DelivererModel.objects.get(id=payload['assigned_deliverer_id'])
     assert deliverer.status == DelivererStatus.OCCUPIED.value
 
 
-@then('a nova atribuição deve escolher outro entregador disponível')
-def assert_reassigned_to_other(context: dict):
+@then(parsers.parse('a ordem deve ser atribuida ao entregador "{name}"'))
+def assert_order_assigned_to_named_deliverer(context: dict, name: str):
+    payload = context['response']
+    expected_id = context['deliverers_by_name'][name]['id']
+    assert payload['assigned_deliverer_id'] == expected_id
+
+
+@then(parsers.parse('o sistema deve retornar erro "{message}"'))
+def assert_assignment_error(context: dict, message: str):
+    assert context['status_code'] == 400
+    assert context['response']['error'] == message
+
+
+@then('a nova atribuicao deve escolher outro entregador disponivel')
+def assert_reassignment_changed_deliverer(context: dict):
     original_id = context['order']['assigned_deliverer_id']
-    response = context['response']
-    assert response['assigned_deliverer_id'] != original_id
+    current_id = context['response']['assigned_deliverer_id']
+    assert current_id != original_id
 
 
 @then('a ordem deve continuar em "IN_DELIVERY"')
-def assert_order_still_in_delivery(context: dict):
-    payload = context['response']
-    assert payload['status'] == OrderStatus.IN_DELIVERY.value
+def assert_order_stays_in_delivery(context: dict):
+    assert context['response']['status'] == OrderStatus.IN_DELIVERY.value


### PR DESCRIPTION
## Summary
- refine deliverers backend service rules and REST endpoints
- expand BDD scenarios and step coverage for mandatory flows
- add deliverers feature guide
- add functional frontend deliverers list screen with reusable components

## Validation
- frontend build: npm run build
- backend bdd: python3 -m pytest -q tests/steps/test_deliverers_steps.py (8 passed)
